### PR TITLE
Fixed the example for the two stepper expansion board

### DIFF
--- a/config/generic-duet2-maestro.cfg
+++ b/config/generic-duet2-maestro.cfg
@@ -105,8 +105,8 @@ stealthchop_threshold: 999999
 #...
 
 # External steppers
-# e2: step_pin=PC31 dir_pin=PA18 enable_pin=PC27 select_pins=PC14,!PC16,PC17
-# e3: step_pin=PC21 dir_pin=PC24 enable_pin=PC25 select_pins=!PC14,PC16,PC17
+# e2: step_pin=PC31 dir_pin=PA18 enable_pin=!PC27 select_pins=PC14,!PC16,PC17
+# e3: step_pin=PC21 dir_pin=PC24 enable_pin=!PC25 select_pins=!PC14,PC16,PC17
 # e0_stop: endstop_pin=PA25
 # e1_stop: endstop_pin=PC7
 # c_temp: sensor_pin=PB1


### PR DESCRIPTION
These enable pins for the driver expansion board need to be inverted,identically to the on board drivers.